### PR TITLE
Fix and rename the version sort (--version-sort / --vs)

### DIFF
--- a/.aspelldict
+++ b/.aspelldict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 130
+personal_ws-1.1 en 131
 AliasVar
 CMD
 CPAN
@@ -92,6 +92,7 @@ perllocale
 pfn
 pre
 printf
+projectname
 ptp
 qw
 rg

--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 Revision history for Perl distribution App-PTP
 
 1.19 - ????-??-??
- - Fix --semver-sort (--ss) to recognize multi-segment path-like prefixes (e.g.
+ - Rename the --semver-sort (--ss) command to --version-sort (--vs). The old
+   names are no longer recognized.
+ - Fix --version-sort (--vs) to recognize multi-segment path-like prefixes (e.g.
    "refs/tags/projectname/v1.0.0") so the version part is sorted correctly
    instead of the whole prefix being treated as 0.
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl distribution App-PTP
 
+1.19 - ????-??-??
+ - Fix --semver-sort (--ss) to recognize multi-segment path-like prefixes (e.g.
+   "refs/tags/projectname/v1.0.0") so the version part is sorted correctly
+   instead of the whole prefix being treated as 0.
+
 1.18 - 2026-05-23
  - Add a --semver-sort (--ss) command to sort version strings.
 

--- a/lib/App/PTP/Args.pm
+++ b/lib/App/PTP/Args.pm
@@ -238,9 +238,9 @@ sub action_flags {
       my $opt = {%modes, comparator => \'locale'};
       push @{$cur_pipeline}, ['locale-sort', \&do_sort, $opt];
     },
-    'semver-sort|ss' => sub {
+    'version-sort|vs' => sub {
       my $opt = {%modes, comparator => \'semver'};
-      push @{$cur_pipeline}, ['semver-sort', \&do_sort, $opt];
+      push @{$cur_pipeline}, ['version-sort', \&do_sort, $opt];
     },
     'custom-sort|cs=s' => sub {
       my $opt = {%modes, comparator => $_[1]};

--- a/lib/App/PTP/Cheat_Sheet.pod
+++ b/lib/App/PTP/Cheat_Sheet.pod
@@ -53,7 +53,7 @@ Pipeline commands are applied, in order, to all the input files.
 =item B<-M> I<module>: load the given module
 
 =item B<--sort>, B<--ns> (B<--numeric-sort>), B<--ls> (B<--locale-sort>),
-B<--ss> (B<--semver-sort>), B<--cs> I<code> (B<--custom-sort>)
+B<--vs> (B<--version-sort>), B<--cs> I<code> (B<--custom-sort>)
 
 =item B<-u> (B<--unique>), B<--gu> (B<--global-unique>)
 

--- a/lib/App/PTP/Util/Semver.pm
+++ b/lib/App/PTP/Util/Semver.pm
@@ -1,10 +1,12 @@
 # This module compares version strings following the precedence rules of the
 # Semantic Versioning specification (https://semver.org, item 11). It is lenient
-# about the structure of the input: an optional path-like prefix (anything up to
-# a first '/', as long as there is no '.' before it) and an optional leading 'v'
-# are recognized, and the version core may have any number of dot-separated
-# numeric components (missing components are treated as 0, so that "1.1" and
-# "1.1.0" compare as equal).
+# about the structure of the input: an optional path-like prefix (one or more
+# leading '/'-terminated segments, none of which contains a '.') and an optional
+# leading 'v' are recognized, and the version core may have any number of
+# dot-separated numeric components (missing components are treated as 0, so that
+# "1.1" and "1.1.0" compare as equal). The prefix is compared alphabetically,
+# which lets tags such as "refs/tags/projectname/v1.0.0" be grouped by their
+# path and then ordered by their semver part.
 
 package App::PTP::Util::Semver;
 
@@ -28,7 +30,12 @@ sub parse {
   my $original = $version;
   my @warnings;
   $version =~ s/\+.*//s;
-  my $prefix = $version =~ s{^([^./]+)/}{} ? $1 : '';
+  # The prefix is any number of leading '/'-terminated segments, as long as none
+  # of them contains a '.' (a dot before a slash means we have already reached
+  # the version part, e.g. "1.2/3", and the slash is not a prefix separator).
+  # The trailing '/' is dropped so the prefix compares as a plain path string.
+  my $prefix = $version =~ s{^((?:[^./]+/)+)}{} ? $1 : '';
+  $prefix =~ s{/$}{};
   $version =~ s/^v//i;
   my ($core, $pre) = split /-/, $version, 2;
   my @core = split /\./, $core // '';

--- a/script/ptp
+++ b/script/ptp
@@ -296,8 +296,10 @@ Sort the content of the input as version strings, following the precedence
 rules of L<Semantic Versioning|https://semver.org>. So, for example, C<1.9.0>
 sorts before C<1.10.0> (instead of after it as a lexicographic sort would do)
 and a pre-release version such as C<1.0.0-alpha> sorts before the corresponding
-release C<1.0.0>. An optional leading C<v> and an optional prefix terminated by
-C</> are also recognized.
+release C<1.0.0>. An optional leading C<v> and an optional path-like prefix made
+of one or more C</>-terminated segments are also recognized, so that tags such
+as C<refs/tags/projectname/v1.0.0> are grouped by their prefix (compared
+alphabetically) and then ordered by their version.
 
 The markers of the input lines are reset (no line is marked after this command).
 

--- a/script/ptp
+++ b/script/ptp
@@ -290,7 +290,7 @@ like correctly comparing equivalent characters and/or ignoring the case.
 
 The markers of the input lines are reset (no line is marked after this command).
 
-=item B<--ss>, B<--semver-sort>
+=item B<--vs>, B<--version-sort>
 
 Sort the content of the input as version strings, following the precedence
 rules of L<Semantic Versioning|https://semver.org>. So, for example, C<1.9.0>

--- a/t/203-command-sort.t
+++ b/t/203-command-sort.t
@@ -48,27 +48,27 @@ my $numeric_input = "20ab\n1d\n20.5\n99\nabc\n";
 }
 
 {
-  my $data = ptp([qw(--ss)], \"1.10.0\n1.2.0\n1.9.0\n");
+  my $data = ptp([qw(--vs)], \"1.10.0\n1.2.0\n1.9.0\n");
   is($data, "1.2.0\n1.9.0\n1.10.0\n", 'semver sort');
 }{
   # A pre-release version sorts before the corresponding release.
-  my $data = ptp([qw(--ss)], \"1.1\n1.1-alpha1\n");
+  my $data = ptp([qw(--vs)], \"1.1\n1.1-alpha1\n");
   is($data, "1.1-alpha1\n1.1\n", 'semver pre-release sort');
 }{
   # Versions are grouped by their path-like prefix, then ordered by version
   # (the leading "v" is ignored and the major version is honored).
-  my $data = ptp([qw(--ss)], \"ptp/v1.10\nptp/v1.2\nabc/v2.0\nabc/v1.0\n");
+  my $data = ptp([qw(--vs)], \"ptp/v1.10\nptp/v1.2\nabc/v2.0\nabc/v1.0\n");
   is($data, "abc/v1.0\nabc/v2.0\nptp/v1.2\nptp/v1.10\n", 'semver prefix sort');
 }{
   # A multi-segment path-like prefix is recognized in full, so the version part
   # is sorted as a semver instead of the whole prefix being treated as 0.
-  my ($data, $err) = ptp([qw(--ss)],
+  my ($data, $err) = ptp([qw(--vs)],
     \"refs/tags/ptp/v1.10\nrefs/tags/ptp/v1.2\nrefs/tags/abc/v2.0\n");
   is($data, "refs/tags/abc/v2.0\nrefs/tags/ptp/v1.2\nrefs/tags/ptp/v1.10\n",
      'semver sort with a multi-segment prefix');
 }{
   # A non-numeric core component is treated as 0 and triggers a warning.
-  my ($data, $err) = ptp([qw(--ss)], \"abc\n1.0\n");
+  my ($data, $err) = ptp([qw(--vs)], \"abc\n1.0\n");
   is($data, "abc\n1.0\n", 'semver sort with a non-numeric value');
   like($err, qr/WARNING: version 'abc' has a non-numeric component 'abc'/,
        'semver sort warns about non-numeric values');

--- a/t/203-command-sort.t
+++ b/t/203-command-sort.t
@@ -7,7 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 
 use AppPtpTest;
-use Test::More tests => 12;
+use Test::More tests => 13;
 
 {
   my $data = ptp([qw(--sort)], 'default_data.txt');
@@ -59,6 +59,13 @@ my $numeric_input = "20ab\n1d\n20.5\n99\nabc\n";
   # (the leading "v" is ignored and the major version is honored).
   my $data = ptp([qw(--ss)], \"ptp/v1.10\nptp/v1.2\nabc/v2.0\nabc/v1.0\n");
   is($data, "abc/v1.0\nabc/v2.0\nptp/v1.2\nptp/v1.10\n", 'semver prefix sort');
+}{
+  # A multi-segment path-like prefix is recognized in full, so the version part
+  # is sorted as a semver instead of the whole prefix being treated as 0.
+  my ($data, $err) = ptp([qw(--ss)],
+    \"refs/tags/ptp/v1.10\nrefs/tags/ptp/v1.2\nrefs/tags/abc/v2.0\n");
+  is($data, "refs/tags/abc/v2.0\nrefs/tags/ptp/v1.2\nrefs/tags/ptp/v1.10\n",
+     'semver sort with a multi-segment prefix');
 }{
   # A non-numeric core component is treated as 0 and triggers a warning.
   my ($data, $err) = ptp([qw(--ss)], \"abc\n1.0\n");

--- a/t/500-util-semver.t
+++ b/t/500-util-semver.t
@@ -32,6 +32,15 @@ cmp_ok_sign('v1.2', '1.2', 0, 'a leading v is ignored');
 my $dotted = App::PTP::Util::Semver::parse('1.2/3');
 is($dotted->{prefix}, '', 'no prefix when a dot precedes the slash');
 
+# A multi-segment path-like prefix is recognized in full (the version part is
+# the trailing 'v1.0.0', not 0 because of an over-eager dot split).
+my $nested = App::PTP::Util::Semver::parse('refs/tags/projectname/v1.0.0');
+is($nested->{prefix}, 'refs/tags/projectname', 'the full multi-segment prefix is captured');
+is_deeply($nested->{core}, [1, 0, 0], 'the version core follows the multi-segment prefix');
+is_deeply($nested->{warnings}, [], 'a multi-segment prefix produces no warning');
+cmp_ok_sign('refs/tags/p/v1.9.0', 'refs/tags/p/v1.10.0', -1,
+  'nested prefixes are grouped and ordered by version');
+
 # Parsing warnings for non-numeric core components.
 is_deeply(App::PTP::Util::Semver::parse('1.2.3')->{warnings}, [],
   'a clean version produces no warning');


### PR DESCRIPTION
Two related changes to the version sorting command.

## Fix multi-segment path-like prefixes

The prefix detection only consumed a single path segment, so a tag like
`refs/tags/projectname/v1.0.0` kept `tags/projectname/v1.0.0` as the version
core. Splitting that on `.` made the first component `tags/projectname/v1`
non-numeric, which was treated as 0 and broke the ordering (and emitted a
spurious warning).

The prefix is now recognized as one or more leading `/`-terminated segments that
contain no `.`, so the whole non-numeric path is compared alphabetically and the
trailing `v1.0.0` is parsed as the version part.

## Rename --semver-sort/--ss to --version-sort/--vs

The command is now spelled `--version-sort` (short `--vs`). The old
`--semver-sort`/`--ss` names are removed entirely — no backwards compatibility
is kept. `--vs` does not conflict with any existing flag.

Documentation (both the main POD in `script/ptp` and the cheat sheet) and tests
are updated accordingly, and the `Changes` file records both the rename and the
fix under the unreleased `1.19` entry.